### PR TITLE
Updated Config 45 (v3 Test)

### DIFF
--- a/rovpp_pkg/tests/engine_tests/engine_test_configs/__init__.py
+++ b/rovpp_pkg/tests/engine_tests/engine_test_configs/__init__.py
@@ -38,6 +38,10 @@ from .config_071 import Config071
 from .config_072 import Config072
 from .config_073 import Config073
 from .config_074 import Config074
+from .config_075 import Config075
+from .config_076 import Config076
+from .config_077 import Config077
+from .config_078 import Config078
 
 
 
@@ -80,4 +84,9 @@ __all__ = ["Config035",
            "Config071",
            "Config072",
            "Config073",
-           "Config074"]
+           "Config074",
+           "Config075",
+           "Config076",
+           "Config077",
+           "Config078"
+           ]

--- a/rovpp_pkg/tests/engine_tests/engine_test_configs/config_045.py
+++ b/rovpp_pkg/tests/engine_tests/engine_test_configs/config_045.py
@@ -24,5 +24,8 @@ class Config045(EngineTestConfig):
                                BaseASCls=BGPSimpleAS,
                                AnnCls=ROVPPAnn)
     graph = graphs.Graph005()
-    non_default_as_cls_dict: Dict[int, Type[AS]] = {5: ROVPPV3AS}
+    non_default_as_cls_dict: Dict[int, Type[AS]] = {5: ROVPPV3AS,
+                                                    8: ROVPPV3AS,
+                                                    10: ROVPPV3AS,
+                                                    15: ROVPPV3AS}
     propagation_rounds = 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_configs/config_075.py
+++ b/rovpp_pkg/tests/engine_tests/engine_test_configs/config_075.py
@@ -1,0 +1,31 @@
+from typing import Dict, Type
+
+from caida_collector_pkg import AS
+
+from bgp_simulator_pkg import graphs
+from bgp_simulator_pkg import EngineTestConfig
+
+from bgp_simulator_pkg import BGPSimpleAS
+from bgp_simulator_pkg import ASNs
+from bgp_simulator_pkg import NonRoutedPrefixHijack
+from bgp_simulator_pkg import ROVSimpleAS
+
+from rovpp_pkg import ROVPPAnn
+
+
+class Config075(EngineTestConfig):
+    """Contains config options to run a test"""
+
+    name = "075"
+    desc = "NonRouted Prefix Hijack with ROV"
+
+    scenario = NonRoutedPrefixHijack(attacker_asns={ASNs.ATTACKER.value},
+                                     victim_asns={ASNs.VICTIM.value},
+                                     AdoptASCls=ROVSimpleAS,
+                                     BaseASCls=BGPSimpleAS,
+                                     AnnCls=ROVPPAnn)
+    graph = graphs.Graph048()
+    non_default_as_cls_dict: Dict[int, Type[AS]] = {3: ROVSimpleAS,
+                                                    4: ROVSimpleAS,
+                                                    6: ROVSimpleAS}
+    propagation_rounds = 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_configs/config_076.py
+++ b/rovpp_pkg/tests/engine_tests/engine_test_configs/config_076.py
@@ -1,0 +1,31 @@
+from typing import Dict, Type
+
+from caida_collector_pkg import AS
+
+from bgp_simulator_pkg import graphs
+from bgp_simulator_pkg import EngineTestConfig
+
+from bgp_simulator_pkg import BGPSimpleAS
+from bgp_simulator_pkg import ASNs
+from bgp_simulator_pkg import NonRoutedPrefixHijack
+
+from rovpp_pkg import ROVPPAnn
+from rovpp_pkg import ROVPPV1SimpleAS
+
+
+class Config076(EngineTestConfig):
+    """Contains config options to run a test"""
+
+    name = "076"
+    desc = "NonRouted Prefix Hijack with v1"
+
+    scenario = NonRoutedPrefixHijack(attacker_asns={ASNs.ATTACKER.value},
+                                     victim_asns={ASNs.VICTIM.value},
+                                     AdoptASCls=ROVPPV1SimpleAS,
+                                     BaseASCls=BGPSimpleAS,
+                                     AnnCls=ROVPPAnn)
+    graph = graphs.Graph048()
+    non_default_as_cls_dict: Dict[int, Type[AS]] = {3: ROVPPV1SimpleAS,
+                                                    4: ROVPPV1SimpleAS,
+                                                    6: ROVPPV1SimpleAS}
+    propagation_rounds = 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_configs/config_077.py
+++ b/rovpp_pkg/tests/engine_tests/engine_test_configs/config_077.py
@@ -1,0 +1,31 @@
+from typing import Dict, Type
+
+from caida_collector_pkg import AS
+
+from bgp_simulator_pkg import graphs
+from bgp_simulator_pkg import EngineTestConfig
+
+from bgp_simulator_pkg import BGPSimpleAS
+from bgp_simulator_pkg import ASNs
+from bgp_simulator_pkg import NonRoutedPrefixHijack
+
+from rovpp_pkg import ROVPPAnn
+from rovpp_pkg import ROVPPV2SimpleAS
+
+
+class Config077(EngineTestConfig):
+    """Contains config options to run a test"""
+
+    name = "077"
+    desc = "NonRouted Prefix Hijack with v2"
+
+    scenario = NonRoutedPrefixHijack(attacker_asns={ASNs.ATTACKER.value},
+                                     victim_asns={ASNs.VICTIM.value},
+                                     AdoptASCls=ROVPPV2SimpleAS,
+                                     BaseASCls=BGPSimpleAS,
+                                     AnnCls=ROVPPAnn)
+    graph = graphs.Graph048()
+    non_default_as_cls_dict: Dict[int, Type[AS]] = {3: ROVPPV2SimpleAS,
+                                                    4: ROVPPV2SimpleAS,
+                                                    6: ROVPPV2SimpleAS}
+    propagation_rounds = 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_configs/config_078.py
+++ b/rovpp_pkg/tests/engine_tests/engine_test_configs/config_078.py
@@ -1,0 +1,31 @@
+from typing import Dict, Type
+
+from caida_collector_pkg import AS
+
+from bgp_simulator_pkg import graphs
+from bgp_simulator_pkg import EngineTestConfig
+
+from bgp_simulator_pkg import BGPSimpleAS
+from bgp_simulator_pkg import ASNs
+from bgp_simulator_pkg import NonRoutedPrefixHijack
+
+from rovpp_pkg import ROVPPAnn
+from rovpp_pkg import ROVPPV2aSimpleAS
+
+
+class Config078(EngineTestConfig):
+    """Contains config options to run a test"""
+
+    name = "078"
+    desc = "NonRouted Prefix Hijack with v2a"
+
+    scenario = NonRoutedPrefixHijack(attacker_asns={ASNs.ATTACKER.value},
+                                     victim_asns={ASNs.VICTIM.value},
+                                     AdoptASCls=ROVPPV2aSimpleAS,
+                                     BaseASCls=BGPSimpleAS,
+                                     AnnCls=ROVPPAnn)
+    graph = graphs.Graph048()
+    non_default_as_cls_dict: Dict[int, Type[AS]] = {3: ROVPPV2aSimpleAS,
+                                                    4: ROVPPV2aSimpleAS,
+                                                    6: ROVPPV2aSimpleAS}
+    propagation_rounds = 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/035/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/035/engine_gt.yaml
@@ -24,7 +24,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -235,7 +235,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -275,7 +275,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/035/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/035/engine_guess.yaml
@@ -24,7 +24,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -235,7 +235,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -275,7 +275,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/036/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/036/engine_gt.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -105,7 +105,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -142,7 +142,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -180,7 +180,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -191,7 +191,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -230,7 +230,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -267,7 +267,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -305,7 +305,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -336,7 +336,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -481,7 +481,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -529,7 +529,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/036/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/036/engine_guess.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -105,7 +105,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -142,7 +142,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -180,7 +180,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -191,7 +191,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -230,7 +230,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -267,7 +267,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -305,7 +305,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -336,7 +336,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -481,7 +481,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -529,7 +529,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/037/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/037/engine_gt.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -105,7 +105,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -142,7 +142,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -180,7 +180,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -191,7 +191,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -370,7 +370,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -418,7 +418,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/037/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/037/engine_guess.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -105,7 +105,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -142,7 +142,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -180,7 +180,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -191,7 +191,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -370,7 +370,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -418,7 +418,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/038/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/038/engine_gt.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -373,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -493,7 +493,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -542,7 +542,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/038/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/038/engine_guess.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -373,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -493,7 +493,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -542,7 +542,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/039/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/039/engine_gt.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -373,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -493,7 +493,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -542,7 +542,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/039/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/039/engine_guess.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -373,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -493,7 +493,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -542,7 +542,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/engine_gt.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -360,11 +360,12 @@
     1.2.3.0/24: !yamlable/ROVPPAnn
       as_path: !!python/tuple
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
-      blackhole: true
+      blackhole: false
       holes: !!python/tuple []
       prefix: 1.2.3.0/24
       preventive: false
@@ -372,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -440,11 +441,12 @@
       - !yamlable/ROVPPAnn
         as_path: !!python/tuple
         - 6
-        - 4
+        - 3
+        - 2
         - 1
         - 666
         attacker_on_route: false
-        blackhole: true
+        blackhole: false
         holes: !!python/tuple []
         prefix: 1.2.3.0/24
         preventive: false
@@ -452,7 +454,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -472,7 +474,8 @@
       as_path: !!python/tuple
       - 8
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
@@ -481,11 +484,12 @@
         ? !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -493,7 +497,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -524,11 +528,12 @@
         - !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -536,7 +541,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +552,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +601,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +650,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/engine_guess.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -360,11 +360,12 @@
     1.2.3.0/24: !yamlable/ROVPPAnn
       as_path: !!python/tuple
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
-      blackhole: true
+      blackhole: false
       holes: !!python/tuple []
       prefix: 1.2.3.0/24
       preventive: false
@@ -372,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -440,11 +441,12 @@
       - !yamlable/ROVPPAnn
         as_path: !!python/tuple
         - 6
-        - 4
+        - 3
+        - 2
         - 1
         - 666
         attacker_on_route: false
-        blackhole: true
+        blackhole: false
         holes: !!python/tuple []
         prefix: 1.2.3.0/24
         preventive: false
@@ -452,7 +454,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -472,7 +474,8 @@
       as_path: !!python/tuple
       - 8
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
@@ -481,11 +484,12 @@
         ? !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -493,7 +497,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -524,11 +528,12 @@
         - !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -536,7 +541,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +552,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +601,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +650,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/outcomes_gt.yaml
@@ -14,11 +14,11 @@
   name: ATTACKER_SUCCESS
   value: 0
 6: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 7: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 8: !simulator_codec/Outcomes
   name: DISCONNECTED
   value: 2

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/040/outcomes_guess.yaml
@@ -14,11 +14,11 @@
   name: ATTACKER_SUCCESS
   value: 0
 6: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 7: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 8: !simulator_codec/Outcomes
   name: DISCONNECTED
   value: 2

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/engine_gt.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -360,11 +360,12 @@
     1.2.3.0/24: !yamlable/ROVPPAnn
       as_path: !!python/tuple
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
-      blackhole: true
+      blackhole: false
       holes: !!python/tuple []
       prefix: 1.2.3.0/24
       preventive: false
@@ -372,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -440,11 +441,12 @@
       - !yamlable/ROVPPAnn
         as_path: !!python/tuple
         - 6
-        - 4
+        - 3
+        - 2
         - 1
         - 666
         attacker_on_route: false
-        blackhole: true
+        blackhole: false
         holes: !!python/tuple []
         prefix: 1.2.3.0/24
         preventive: false
@@ -452,7 +454,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -472,7 +474,8 @@
       as_path: !!python/tuple
       - 8
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
@@ -481,11 +484,12 @@
         ? !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -493,7 +497,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -524,11 +528,12 @@
         - !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -536,7 +541,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +552,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +601,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +650,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/engine_guess.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -360,11 +360,12 @@
     1.2.3.0/24: !yamlable/ROVPPAnn
       as_path: !!python/tuple
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
-      blackhole: true
+      blackhole: false
       holes: !!python/tuple []
       prefix: 1.2.3.0/24
       preventive: false
@@ -372,7 +373,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -440,11 +441,12 @@
       - !yamlable/ROVPPAnn
         as_path: !!python/tuple
         - 6
-        - 4
+        - 3
+        - 2
         - 1
         - 666
         attacker_on_route: false
-        blackhole: true
+        blackhole: false
         holes: !!python/tuple []
         prefix: 1.2.3.0/24
         preventive: false
@@ -452,7 +454,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -472,7 +474,8 @@
       as_path: !!python/tuple
       - 8
       - 6
-      - 4
+      - 3
+      - 2
       - 1
       - 666
       attacker_on_route: false
@@ -481,11 +484,12 @@
         ? !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -493,7 +497,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -524,11 +528,12 @@
         - !yamlable/ROVPPAnn
           as_path: !!python/tuple
           - 6
-          - 4
+          - 3
+          - 2
           - 1
           - 666
           attacker_on_route: false
-          blackhole: true
+          blackhole: false
           holes: !!python/tuple []
           prefix: 1.2.3.0/24
           preventive: false
@@ -536,7 +541,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +552,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +601,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +650,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/outcomes_gt.yaml
@@ -14,11 +14,11 @@
   name: ATTACKER_SUCCESS
   value: 0
 6: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 7: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 8: !simulator_codec/Outcomes
   name: DISCONNECTED
   value: 2

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/041/outcomes_guess.yaml
@@ -14,11 +14,11 @@
   name: ATTACKER_SUCCESS
   value: 0
 6: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 7: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: ATTACKER_SUCCESS
+  value: 0
 8: !simulator_codec/Outcomes
   name: DISCONNECTED
   value: 2

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/042/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/042/engine_gt.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -372,7 +372,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -452,7 +452,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -493,7 +493,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -536,7 +536,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +547,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +596,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +645,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/042/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/042/engine_guess.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -372,7 +372,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -452,7 +452,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -493,7 +493,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -536,7 +536,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +547,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +596,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +645,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/043/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/043/engine_gt.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -372,7 +372,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -452,7 +452,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -493,7 +493,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -536,7 +536,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +547,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +596,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +645,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/043/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/043/engine_guess.yaml
@@ -33,7 +33,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -87,7 +87,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -141,7 +141,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -181,7 +181,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -218,7 +218,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -257,7 +257,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -268,7 +268,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -372,7 +372,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -452,7 +452,7 @@
           name: PROVIDERS
           value: 1
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -493,7 +493,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -536,7 +536,7 @@
             name: PROVIDERS
             value: 1
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -547,7 +547,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -596,7 +596,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +645,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/044/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/044/engine_gt.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -85,7 +85,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -169,7 +169,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -263,7 +263,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -374,7 +374,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -486,7 +486,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -543,7 +543,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -600,7 +600,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -659,7 +659,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -719,7 +719,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -769,7 +769,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -817,7 +817,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/044/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/044/engine_guess.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -85,7 +85,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -169,7 +169,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -263,7 +263,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -318,7 +318,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -374,7 +374,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -486,7 +486,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -543,7 +543,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -600,7 +600,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -659,7 +659,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -719,7 +719,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -769,7 +769,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -817,7 +817,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/045/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/045/engine_gt.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -85,7 +85,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -169,7 +169,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -269,7 +269,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -392,7 +392,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -502,7 +502,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -557,7 +557,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -614,7 +614,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -727,7 +727,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -845,7 +845,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -895,7 +895,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -943,7 +943,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/045/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/045/engine_guess.yaml
@@ -32,7 +32,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -85,7 +85,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -169,7 +169,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -269,7 +269,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -392,7 +392,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -502,7 +502,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -557,7 +557,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -614,7 +614,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -727,7 +727,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -845,7 +845,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -895,7 +895,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -943,7 +943,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/046/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/046/engine_gt.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -223,7 +223,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -306,7 +306,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -354,7 +354,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/046/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/046/engine_guess.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -223,7 +223,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -306,7 +306,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -354,7 +354,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/047/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/047/engine_gt.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -223,7 +223,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -306,7 +306,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -354,7 +354,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/047/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/047/engine_guess.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -223,7 +223,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -306,7 +306,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -354,7 +354,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/048/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/048/engine_gt.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -162,7 +162,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -215,7 +215,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -263,7 +263,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -319,7 +319,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -367,7 +367,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -415,7 +415,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/048/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/048/engine_guess.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -162,7 +162,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -215,7 +215,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -263,7 +263,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -319,7 +319,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -367,7 +367,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -415,7 +415,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/049/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/049/engine_gt.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -162,7 +162,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -215,7 +215,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -263,7 +263,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -319,7 +319,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -367,7 +367,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -415,7 +415,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/049/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/049/engine_guess.yaml
@@ -22,7 +22,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -59,7 +59,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -97,7 +97,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -108,7 +108,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -162,7 +162,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -215,7 +215,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -263,7 +263,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -319,7 +319,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -367,7 +367,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -415,7 +415,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/058/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/058/engine_gt.yaml
@@ -34,7 +34,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -86,7 +86,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -139,7 +139,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -182,7 +182,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -221,7 +221,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -262,7 +262,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -273,7 +273,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -324,7 +324,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -378,7 +378,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -433,7 +433,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -492,7 +492,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -548,7 +548,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -598,7 +598,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -648,7 +648,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/058/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/058/engine_guess.yaml
@@ -34,7 +34,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -86,7 +86,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -139,7 +139,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -182,7 +182,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -221,7 +221,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -262,7 +262,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -273,7 +273,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -324,7 +324,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -378,7 +378,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -433,7 +433,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -492,7 +492,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -548,7 +548,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -598,7 +598,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -648,7 +648,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/059/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/059/engine_gt.yaml
@@ -34,7 +34,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -86,7 +86,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -139,7 +139,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -182,7 +182,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -221,7 +221,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -262,7 +262,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -273,7 +273,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -324,7 +324,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -378,7 +378,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -432,7 +432,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -490,7 +490,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -545,7 +545,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -595,7 +595,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +645,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/059/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/059/engine_guess.yaml
@@ -34,7 +34,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -86,7 +86,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -139,7 +139,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -182,7 +182,7 @@
           name: CUSTOMERS
           value: 3
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -221,7 +221,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -262,7 +262,7 @@
             name: CUSTOMERS
             value: 3
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -273,7 +273,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -324,7 +324,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -378,7 +378,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -432,7 +432,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -490,7 +490,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -545,7 +545,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -595,7 +595,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -645,7 +645,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/069/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/069/engine_gt.yaml
@@ -228,7 +228,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -265,7 +265,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -303,7 +303,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -314,7 +314,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -364,7 +364,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/069/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/069/engine_guess.yaml
@@ -228,7 +228,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -265,7 +265,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -303,7 +303,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -314,7 +314,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -364,7 +364,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/070/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/070/engine_gt.yaml
@@ -228,7 +228,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -265,7 +265,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -303,7 +303,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -314,7 +314,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -364,7 +364,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/070/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/070/engine_guess.yaml
@@ -228,7 +228,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -265,7 +265,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -303,7 +303,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -314,7 +314,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -364,7 +364,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/engine_gt.yaml
@@ -4,9 +4,8 @@
     1.2.0.0/16: !yamlable/ROVPPAnn
       as_path: !!python/tuple
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -40,9 +39,8 @@
       as_path: !!python/tuple
       - 6
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -77,9 +75,8 @@
       - 7
       - 6
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -113,9 +110,8 @@
       - 8
       - 6
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -232,7 +228,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -269,7 +265,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -307,7 +303,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -318,7 +314,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -368,7 +364,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -433,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/engine_guess.yaml
@@ -4,9 +4,8 @@
     1.2.0.0/16: !yamlable/ROVPPAnn
       as_path: !!python/tuple
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -40,9 +39,8 @@
       as_path: !!python/tuple
       - 6
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -77,9 +75,8 @@
       - 7
       - 6
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -113,9 +110,8 @@
       - 8
       - 6
       - 1
-      - 11
-      - 12
-      - 135
+      - 33
+      - 34
       - 777
       attacker_on_route: false
       blackhole: false
@@ -232,7 +228,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -269,7 +265,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -307,7 +303,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -318,7 +314,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -368,7 +364,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -433,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/outcomes_gt.yaml
@@ -1,15 +1,15 @@
 1: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 6: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 7: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 8: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 11: !simulator_codec/Outcomes
   name: VICTIM_SUCCESS
   value: 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/071/outcomes_guess.yaml
@@ -1,15 +1,15 @@
 1: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 6: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 7: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 8: !simulator_codec/Outcomes
-  name: VICTIM_SUCCESS
-  value: 1
+  name: DISCONNECTED
+  value: 2
 11: !simulator_codec/Outcomes
   name: VICTIM_SUCCESS
   value: 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/072/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/072/engine_gt.yaml
@@ -189,7 +189,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -247,7 +247,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -266,7 +266,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -278,7 +278,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -328,7 +328,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -379,7 +379,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -478,7 +478,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/072/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/072/engine_guess.yaml
@@ -189,7 +189,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -247,7 +247,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -266,7 +266,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -278,7 +278,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -328,7 +328,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -379,7 +379,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -478,7 +478,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/073/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/073/engine_gt.yaml
@@ -189,7 +189,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -247,7 +247,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -266,7 +266,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -278,7 +278,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -328,7 +328,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -379,7 +379,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -478,7 +478,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/073/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/073/engine_guess.yaml
@@ -189,7 +189,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -247,7 +247,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -266,7 +266,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -278,7 +278,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -328,7 +328,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -379,7 +379,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -429,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -478,7 +478,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/engine_gt.yaml
@@ -51,27 +51,6 @@
       timestamp: 0
       traceback_end: false
       withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
-      traceback_end: false
-      withdraw: false
   _recv_q: !yamlable/RecvQueue {}
   asn: 3
   customer_cone_size: 3
@@ -104,28 +83,6 @@
       roa_valid_length: true
       seed_asn: null
       timestamp: 0
-      traceback_end: false
-      withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 6
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
       traceback_end: false
       withdraw: false
   _recv_q: !yamlable/RecvQueue {}
@@ -163,29 +120,6 @@
       timestamp: 0
       traceback_end: false
       withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 7
-      - 6
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
-      traceback_end: false
-      withdraw: false
   _recv_q: !yamlable/RecvQueue {}
   asn: 7
   customer_cone_size: 0
@@ -218,29 +152,6 @@
       roa_valid_length: true
       seed_asn: null
       timestamp: 0
-      traceback_end: false
-      withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 8
-      - 6
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
       traceback_end: false
       withdraw: false
   _recv_q: !yamlable/RecvQueue {}
@@ -278,7 +189,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -336,7 +247,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -355,7 +266,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -367,7 +278,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -417,7 +328,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -468,7 +379,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -518,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -567,7 +478,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/engine_guess.yaml
@@ -51,27 +51,6 @@
       timestamp: 0
       traceback_end: false
       withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
-      traceback_end: false
-      withdraw: false
   _recv_q: !yamlable/RecvQueue {}
   asn: 3
   customer_cone_size: 3
@@ -104,28 +83,6 @@
       roa_valid_length: true
       seed_asn: null
       timestamp: 0
-      traceback_end: false
-      withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 6
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
       traceback_end: false
       withdraw: false
   _recv_q: !yamlable/RecvQueue {}
@@ -163,29 +120,6 @@
       timestamp: 0
       traceback_end: false
       withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 7
-      - 6
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
-      traceback_end: false
-      withdraw: false
   _recv_q: !yamlable/RecvQueue {}
   asn: 7
   customer_cone_size: 0
@@ -218,29 +152,6 @@
       roa_valid_length: true
       seed_asn: null
       timestamp: 0
-      traceback_end: false
-      withdraw: false
-    1.2.3.0/24: !yamlable/ROVPPAnn
-      as_path: !!python/tuple
-      - 8
-      - 6
-      - 3
-      - 33
-      - 56
-      - 78
-      - 666
-      attacker_on_route: false
-      blackhole: true
-      holes: !!python/tuple []
-      prefix: 1.2.3.0/24
-      preventive: false
-      recv_relationship: !simulator_codec/Relationships
-        name: PROVIDERS
-        value: 1
-      roa_origin: 777
-      roa_valid_length: false
-      seed_asn: null
-      timestamp: 1
       traceback_end: false
       withdraw: false
   _recv_q: !yamlable/RecvQueue {}
@@ -278,7 +189,7 @@
           name: PEERS
           value: 2
         roa_origin: 777
-        roa_valid_length: false
+        roa_valid_length: true
         seed_asn: null
         timestamp: 1
         traceback_end: false
@@ -336,7 +247,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -355,7 +266,7 @@
             name: PEERS
             value: 2
           roa_origin: 777
-          roa_valid_length: false
+          roa_valid_length: true
           seed_asn: null
           timestamp: 1
           traceback_end: false
@@ -367,7 +278,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: true
@@ -417,7 +328,7 @@
         name: PEERS
         value: 2
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -468,7 +379,7 @@
         name: CUSTOMERS
         value: 3
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false
@@ -518,7 +429,7 @@
         name: ORIGIN
         value: 4
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: 666
       timestamp: 1
       traceback_end: false
@@ -567,7 +478,7 @@
         name: PROVIDERS
         value: 1
       roa_origin: 777
-      roa_valid_length: false
+      roa_valid_length: true
       seed_asn: null
       timestamp: 1
       traceback_end: false

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/outcomes_gt.yaml
@@ -2,17 +2,17 @@
   name: VICTIM_SUCCESS
   value: 1
 3: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 6: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 7: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 8: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 33: !simulator_codec/Outcomes
   name: DISCONNECTED
   value: 2

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/074/outcomes_guess.yaml
@@ -2,17 +2,17 @@
   name: VICTIM_SUCCESS
   value: 1
 3: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 6: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 7: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 8: !simulator_codec/Outcomes
-  name: DISCONNECTED
-  value: 2
+  name: VICTIM_SUCCESS
+  value: 1
 33: !simulator_codec/Outcomes
   name: DISCONNECTED
   value: 2

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/engine_gt.yaml
@@ -1,0 +1,151 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/engine_guess.yaml
@@ -1,0 +1,151 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/outcomes_gt.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/075/outcomes_guess.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/engine_gt.yaml
@@ -1,0 +1,189 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVPPV1SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVPPV1SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PEERS
+        value: 2
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVPPV1SimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/engine_guess.yaml
@@ -1,0 +1,189 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVPPV1SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVPPV1SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PEERS
+        value: 2
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVPPV1SimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/outcomes_gt.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/076/outcomes_guess.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/engine_gt.yaml
@@ -1,0 +1,229 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVPPV2SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVPPV2SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PEERS
+        value: 2
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVPPV2SimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 7
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 8
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/engine_guess.yaml
@@ -1,0 +1,229 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVPPV2SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVPPV2SimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PEERS
+        value: 2
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVPPV2SimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 7
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 8
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/outcomes_gt.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/077/outcomes_guess.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/engine_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/engine_gt.yaml
@@ -1,0 +1,229 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVPPV2aSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVPPV2aSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PEERS
+        value: 2
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVPPV2aSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 7
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 8
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/engine_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/engine_guess.yaml
@@ -1,0 +1,229 @@
+!yamlable/SimulationEngine
+1: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: CUSTOMERS
+        value: 3
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 1
+  customer_cone_size: 3
+  customers: !!python/tuple
+  - 666
+  - 3
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 4
+  propagation_rank: 2
+  providers: !!python/tuple []
+2: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 2
+  customer_cone_size: 4
+  customers: !!python/tuple
+  - 4
+  - 5
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 2
+  providers: !!python/tuple []
+3: !yamlable/ROVPPV2aSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 3
+  customer_cone_size: 1
+  customers: !!python/tuple
+  - 7
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 1
+4: !yamlable/ROVPPV2aSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PEERS
+        value: 2
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: true
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 4
+  customer_cone_size: 2
+  customers: !!python/tuple
+  - 8
+  - 6
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple
+  - 1
+  propagation_rank: 1
+  providers: !!python/tuple
+  - 2
+5: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 5
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 2
+6: !yamlable/ROVPPV2aSimpleAS
+  _local_rib: !yamlable/LocalRIB {}
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 6
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+7: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 7
+      - 3
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 7
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 3
+8: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 8
+      - 4
+      - 1
+      - 666
+      attacker_on_route: false
+      blackhole: true
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: PROVIDERS
+        value: 1
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: null
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 8
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 4
+666: !yamlable/BGPSimpleAS
+  _local_rib: !yamlable/LocalRIB
+    1.2.0.0/16: !yamlable/ROVPPAnn
+      as_path: !!python/tuple
+      - 666
+      attacker_on_route: false
+      blackhole: false
+      holes: !!python/tuple []
+      prefix: 1.2.0.0/16
+      preventive: false
+      recv_relationship: !simulator_codec/Relationships
+        name: ORIGIN
+        value: 4
+      roa_origin: 0
+      roa_valid_length: true
+      seed_asn: 666
+      timestamp: 1
+      traceback_end: false
+      withdraw: false
+  _recv_q: !yamlable/RecvQueue {}
+  asn: 666
+  customer_cone_size: 0
+  customers: !!python/tuple []
+  input_clique: false
+  ixp: false
+  peers: !!python/tuple []
+  propagation_rank: 0
+  providers: !!python/tuple
+  - 1

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/outcomes_gt.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/outcomes_gt.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/outcomes_guess.yaml
+++ b/rovpp_pkg/tests/engine_tests/engine_test_outputs/078/outcomes_guess.yaml
@@ -1,0 +1,27 @@
+1: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0
+2: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+3: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+4: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+5: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+6: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+7: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+8: !simulator_codec/Outcomes
+  name: DISCONNECTED
+  value: 2
+666: !simulator_codec/Outcomes
+  name: ATTACKER_SUCCESS
+  value: 0

--- a/rovpp_pkg/tests/engine_tests/test_engine.py
+++ b/rovpp_pkg/tests/engine_tests/test_engine.py
@@ -45,6 +45,10 @@ from .engine_test_configs import Config071
 from .engine_test_configs import Config072
 from .engine_test_configs import Config073
 from .engine_test_configs import Config074
+from .engine_test_configs import Config075
+from .engine_test_configs import Config076
+from .engine_test_configs import Config077
+from .engine_test_configs import Config078
 
 
 @pytest.mark.engine
@@ -94,7 +98,11 @@ class TestEngine:
                               Config071,
                               Config072,
                               Config073,
-                              Config074])
+                              Config074,
+                              Config075,
+                              Config076,
+                              Config077,
+                              Config078])
     def test_engine(self, conf: EngineTestConfig, overwrite: bool):
         """Performs a system test on the engine
 


### PR DESCRIPTION
Just noticed that some ASes from the original/old test are not set as adopting.  When you run it you'll see the error

```
TypeError: Announcement.copy() got an unexpected keyword argument 'attacker_on_route'
```

Other tests that are failing:  71, 74, 67
These are all v2 related to not making blackholes when expected.

[System Test Tracking Spreadsheet](https://docs.google.com/spreadsheets/d/1MeU8qttmBSGxXXOHxHXYHjsjgSzTeMZVkM0lWaMst0s/edit?usp=sharing)